### PR TITLE
Add configurable cook-off with multi-category ratings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.DS_Store

--- a/public/display.html
+++ b/public/display.html
@@ -3,20 +3,16 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Live Vote – Display</title>
+  <title>Live Results</title>
   <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
   <div class="wrap">
     <div class="card">
-      <h1>Live Results</h1>
-      <p>Votes update in real‑time via WebSockets (Socket.IO).</p>
-      <div style="margin-bottom: 10px;">
+      <h1 id="title">Live Results</h1>
+      <p>Ratings update in real‑time via WebSockets (Socket.IO).</p>
+      <div style="margin-bottom:10px;">
         <button id="reset" class="btn">♻️ Reset</button>
-        <span id="total" class="pill">Total: 0</span>
-      </div>
-      <div class="card">
-        <canvas id="chart"></canvas>
       </div>
       <div id="list" class="grid"></div>
     </div>
@@ -24,51 +20,28 @@
   </div>
 
   <script src="/socket.io/socket.io.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script>
     const socket = io();
     const resetBtn = document.getElementById('reset');
-    const totalEl = document.getElementById('total');
     const list = document.getElementById('list');
-    let chart;
 
-    function ensureChart(labels, data) {
-      const ctx = document.getElementById('chart').getContext('2d');
-      if (chart) return chart;
-      chart = new Chart(ctx, {
-        type: 'bar',
-        data: { labels, datasets: [{ label: 'Votes', data }] },
-        options: {
-          responsive: true, animation: false,
-          scales: { y: { beginAtZero: true, ticks: { precision: 0 } } },
-          plugins: { legend: { display: false } }
-        }
-      });
-      return chart;
-    }
-
-    function renderList(counts) {
+    socket.on('tally', ({ contestName, candidates, categories, counts }) => {
+      document.title = contestName + ' – Live Results';
+      document.getElementById('title').textContent = contestName + ' Results';
       list.innerHTML = '';
-      Object.entries(counts).forEach(([name, value]) => {
+      candidates.forEach(c => {
         const div = document.createElement('div');
         div.className = 'card';
-        div.innerHTML = '<h3>' + name + '</h3><p>' + value + ' votes</p>';
+        const items = categories.map(cat => {
+          const arr = counts[c][cat] || [0,0,0,0,0];
+          const votes = arr.reduce((a,b)=>a+b,0);
+          const sum = arr.reduce((s,n,i)=>s+n*(i+1),0);
+          const avg = votes ? (sum / votes).toFixed(2) : '0.00';
+          return `<li>${cat}: ${avg} ⭐ (${votes} votes)</li>`;
+        }).join('');
+        div.innerHTML = `<h3>${c}</h3><ul>${items}</ul>`;
         list.appendChild(div);
       });
-    }
-
-    socket.on('tally', ({ options, counts }) => {
-      const labels = options;
-      const data = labels.map(l => counts[l] || 0);
-      const total = data.reduce((a,b)=>a+b,0);
-      totalEl.textContent = 'Total: ' + total;
-
-      const c = ensureChart(labels, data);
-      if (JSON.stringify(c.data.labels) !== JSON.stringify(labels)) c.data.labels = labels;
-      c.data.datasets[0].data = data;
-      c.update('none');
-
-      renderList(counts);
     });
 
     resetBtn.onclick = () => socket.emit('reset');

--- a/public/style.css
+++ b/public/style.css
@@ -44,3 +44,10 @@ p { color: var(--muted); margin: 6px 0 12px; }
 .btn-primary { border-color: rgba(34,211,238,0.35); background: linear-gradient(180deg, rgba(34,211,238,0.25), rgba(34,211,238,0.12));}
 .footer { opacity: .8; font-size: 12px; text-align: center; }
 canvas { width: 100% !important; height: auto !important; }
+ul { list-style: none; padding-left: 0; }
+ul li { margin: 4px 0; }
+.category { margin: 8px 0; }
+.category label { display: block; margin-bottom: 4px; font-weight: 600; }
+.ratings { display: flex; gap: 6px; }
+.rating-btn { flex: 1; padding: 8px; border-radius: 8px; cursor: pointer; border: 1px solid rgba(255,255,255,0.18); background: linear-gradient(180deg, rgba(255,255,255,0.10), rgba(255,255,255,0.06)); color: var(--text); }
+.rating-btn.selected { background: var(--accent); color: #000; }

--- a/public/vote.html
+++ b/public/vote.html
@@ -3,19 +3,26 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Live Vote – Cast Your Vote</title>
+  <title>Cast Your Vote</title>
   <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
   <div class="wrap">
     <div class="card">
-      <h1>Cast Your Vote</h1>
-      <p>Tap a button below. The results update instantly on the display page.</p>
-      <div id="buttons" class="grid"></div>
-      <div style="margin-top:10px">
-        <a class="pill" href="/display.html">📊 Open the Live Display</a>
+      <h1 id="title">Cast Your Vote</h1>
+      <p>Rate each entry from 1 (meh) to 5 (🔥).</p>
+      <div style="margin-bottom:10px;">
+        <label for="candidate">Contestant:</label>
+        <select id="candidate"></select>
       </div>
-      <p id="thanks" class="pill" style="display:none; margin-top:10px;">✅ Vote submitted</p>
+      <div id="categories"></div>
+      <div style="margin-top:10px;">
+        <button id="submit" class="btn btn-primary">Submit Vote 🌶️</button>
+      </div>
+      <div style="margin-top:10px;">
+        <a class="pill" href="/display.html">📊 View Live Results</a>
+      </div>
+      <p id="thanks" class="pill" style="display:none; margin-top:10px;">✅ Thanks for voting!</p>
     </div>
     <div class="footer">Demo only — in‑memory votes; resets when the server restarts.</div>
   </div>
@@ -23,25 +30,56 @@
   <script src="/socket.io/socket.io.js"></script>
   <script>
     const socket = io();
-    const buttons = document.getElementById('buttons');
+    const candidateSelect = document.getElementById('candidate');
+    const categoriesDiv = document.getElementById('categories');
     const thanks = document.getElementById('thanks');
+    const selections = {};
+    let categories = [];
 
-    function renderOptions(options) {
-      buttons.innerHTML = '';
-      options.forEach(option => {
-        const btn = document.createElement('button');
-        btn.className = 'btn btn-primary';
-        btn.textContent = option;
-        btn.onclick = () => {
-          socket.emit('cast-vote', { option });
-          thanks.style.display = 'inline-flex';
-          setTimeout(() => (thanks.style.display = 'none'), 1500);
-        };
-        buttons.appendChild(btn);
+    fetch('/config').then(r => r.json()).then(cfg => {
+      document.title = cfg.contestName + ' – Cast Your Vote';
+      document.getElementById('title').textContent = cfg.contestName;
+      cfg.candidates.forEach(c => {
+        const opt = document.createElement('option');
+        opt.value = c;
+        opt.textContent = c;
+        candidateSelect.appendChild(opt);
       });
-    }
+      categories = cfg.categories;
+      categories.forEach(cat => {
+        const div = document.createElement('div');
+        div.className = 'category';
+        const buttons = [1,2,3,4,5].map(n =>
+          `<button type="button" class="rating-btn" data-cat="${cat}" data-val="${n}">${n}</button>`
+        ).join('');
+        div.innerHTML = `<label>${cat}</label><div class="ratings">${buttons}</div>`;
+        categoriesDiv.appendChild(div);
+      });
+    });
 
-    socket.on('tally', ({ options }) => renderOptions(options));
+    categoriesDiv.addEventListener('click', e => {
+      if (!e.target.matches('.rating-btn')) return;
+      const cat = e.target.dataset.cat;
+      const val = Number(e.target.dataset.val);
+      selections[cat] = val;
+      categoriesDiv.querySelectorAll(`.rating-btn[data-cat="${cat}"]`).forEach(btn => {
+        btn.classList.toggle('selected', Number(btn.dataset.val) === val);
+      });
+    });
+
+    document.getElementById('submit').onclick = () => {
+      const candidate = candidateSelect.value;
+      if (!candidate) return;
+      const ratings = {};
+      categories.forEach(cat => {
+        if (selections[cat]) ratings[cat] = selections[cat];
+      });
+      socket.emit('cast-vote', { candidate, ratings });
+      thanks.style.display = 'inline-flex';
+      setTimeout(() => (thanks.style.display = 'none'), 1500);
+      categoriesDiv.querySelectorAll('.rating-btn.selected').forEach(btn => btn.classList.remove('selected'));
+      Object.keys(selections).forEach(k => delete selections[k]);
+    };
   </script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -8,43 +8,69 @@ const app = express();
 const server = http.createServer(app);
 const io = new Server(server);
 
-const OPTIONS = (process.env.OPTIONS || "Red,Blue,Green")
+const CONTEST_NAME = process.env.CONTEST_NAME || 'Chili Cook‑Off';
+const CANDIDATES = (process.env.CANDIDATES || 'Chili 1,Chili 2,Chili 3')
+  .split(',')
+  .map(s => s.trim())
+  .filter(Boolean);
+const CATEGORIES = (process.env.CATEGORIES || 'Appearance,Aroma,Consistency,Taste,Spiciness')
   .split(',')
   .map(s => s.trim())
   .filter(Boolean);
 
-let counts = Object.fromEntries(OPTIONS.map(o => [o, 0]));
+function createEmptyCounts () {
+  return Object.fromEntries(
+    CANDIDATES.map(c => [
+      c,
+      Object.fromEntries(
+        CATEGORIES.map(cat => [cat, [0, 0, 0, 0, 0]])
+      )
+    ])
+  );
+}
+
+let counts = createEmptyCounts();
 
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.get('/', (_req, res) => res.redirect('/vote.html'));
 
+app.get('/config', (_req, res) => {
+  res.json({ contestName: CONTEST_NAME, candidates: CANDIDATES, categories: CATEGORIES });
+});
+
 app.get('/reset', (_req, res) => {
-  counts = Object.fromEntries(OPTIONS.map(o => [o, 0]));
-  io.emit('tally', { options: OPTIONS, counts });
+  counts = createEmptyCounts();
+  io.emit('tally', { contestName: CONTEST_NAME, candidates: CANDIDATES, categories: CATEGORIES, counts });
   res.json({ ok: true, counts });
 });
 
 io.on('connection', (socket) => {
-  socket.emit('tally', { options: OPTIONS, counts });
+  socket.emit('tally', { contestName: CONTEST_NAME, candidates: CANDIDATES, categories: CATEGORIES, counts });
 
-  socket.on('cast-vote', ({ option }) => {
-    if (typeof option !== 'string') return;
-    if (!OPTIONS.includes(option)) return;
-    counts[option] += 1;
-    io.emit('tally', { options: OPTIONS, counts });
+  socket.on('cast-vote', ({ candidate, ratings }) => {
+    if (typeof candidate !== 'string' || !counts[candidate]) return;
+    if (typeof ratings !== 'object' || ratings === null) return;
+    for (const [cat, val] of Object.entries(ratings)) {
+      if (!CATEGORIES.includes(cat)) continue;
+      const n = Number(val);
+      if (n >= 1 && n <= 5) counts[candidate][cat][n - 1] += 1;
+    }
+    io.emit('tally', { contestName: CONTEST_NAME, candidates: CANDIDATES, categories: CATEGORIES, counts });
   });
 
   socket.on('reset', () => {
-    counts = Object.fromEntries(OPTIONS.map(o => [o, 0]));
-    io.emit('tally', { options: OPTIONS, counts });
+    counts = createEmptyCounts();
+    io.emit('tally', { contestName: CONTEST_NAME, candidates: CANDIDATES, categories: CATEGORIES, counts });
   });
 });
 
 const PORT = process.env.PORT || 3000;
 server.listen(PORT, () => {
   console.log(`Live Vote server running on http://localhost:${PORT}`);
-  console.log(`Options: ${OPTIONS.join(' | ')}`);
+  console.log(`Contest: ${CONTEST_NAME}`);
+  console.log(`Candidates: ${CANDIDATES.join(' | ')}`);
+  console.log(`Categories: ${CATEGORIES.join(' | ')}`);
   console.log('Vote page:    /vote.html');
   console.log('Display page: /display.html');
 });


### PR DESCRIPTION
## Summary
- Allow configuring contest name, candidates, and rating categories via environment variables and `/config` endpoint.
- Replace single-option voting with 1-5 ratings per category for each contestant.
- Display real-time average ratings and add styles for rating buttons.
- Ignore `node_modules` and `.DS_Store` files.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node server.js` *(runs and prints server startup information)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbbbf42f8832b98eef9ced8c71de3