### PR TITLE
Add admin setup and chart view

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Contest Setup</title>
+  <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+  <div class="wrap">
+    <div class="card">
+      <h1>Contest Setup</h1>
+      <div style="margin-bottom:10px;">
+        <label for="contest-name">Contest Name:</label>
+        <input id="contest-name" style="width:100%;" />
+      </div>
+      <div style="margin-bottom:10px;">
+        <label for="contestants">Contestants (comma separated):</label>
+        <input id="contestants" style="width:100%;" />
+      </div>
+      <div style="margin-bottom:10px;">
+        <label for="categories">Categories (comma separated):</label>
+        <input id="categories" style="width:100%;" />
+      </div>
+      <div style="margin-top:10px; display:flex; gap:10px;">
+        <button id="save" class="btn btn-primary">Save</button>
+        <button id="reset" class="btn">Reset Votes</button>
+      </div>
+      <p id="status" class="pill" style="display:none; margin-top:10px;">Saved!</p>
+    </div>
+  </div>
+
+  <script>
+    const nameInput = document.getElementById('contest-name');
+    const contestantsInput = document.getElementById('contestants');
+    const categoriesInput = document.getElementById('categories');
+    const status = document.getElementById('status');
+
+    fetch('/config').then(r => r.json()).then(cfg => {
+      nameInput.value = cfg.contestName;
+      contestantsInput.value = cfg.candidates.join(', ');
+      categoriesInput.value = cfg.categories.join(', ');
+    });
+
+    document.getElementById('save').onclick = () => {
+      fetch('/setup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          contestName: nameInput.value,
+          candidates: contestantsInput.value.split(',').map(s => s.trim()).filter(Boolean),
+          categories: categoriesInput.value.split(',').map(s => s.trim()).filter(Boolean)
+        })
+      }).then(() => {
+        status.style.display = 'inline-flex';
+        setTimeout(() => (status.style.display = 'none'), 1500);
+      });
+    };
+
+    document.getElementById('reset').onclick = () => {
+      fetch('/reset');
+    };
+  </script>
+</body>
+</html>

--- a/public/display.html
+++ b/public/display.html
@@ -11,21 +11,67 @@
     <div class="card">
       <h1 id="title">Live Results</h1>
       <p>Ratings update in real‑time via WebSockets (Socket.IO).</p>
-      <div style="margin-bottom:10px;">
+      <div style="margin-bottom:10px; display:flex; gap:10px;">
         <button id="reset" class="btn">♻️ Reset</button>
+        <button id="toggle-chart" class="btn">📈 Toggle Chart</button>
       </div>
       <div id="list" class="grid"></div>
+      <div id="chart-container" style="display:none;">
+        <canvas id="chartCanvas"></canvas>
+      </div>
     </div>
     <div class="footer">Tip: open this on a larger screen and share the vote URL.</div>
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="/socket.io/socket.io.js"></script>
   <script>
     const socket = io();
     const resetBtn = document.getElementById('reset');
     const list = document.getElementById('list');
+    const toggleBtn = document.getElementById('toggle-chart');
+    const chartContainer = document.getElementById('chart-container');
+    let chart;
+    let lastData = null;
 
-    socket.on('tally', ({ contestName, candidates, categories, counts }) => {
+    function updateChart(candidates, categories, counts) {
+      const averages = candidates.map(c => {
+        let totalVotes = 0;
+        let totalScore = 0;
+        categories.forEach(cat => {
+          const arr = counts[c][cat] || [0,0,0,0,0];
+          totalVotes += arr.reduce((a,b)=>a+b,0);
+          totalScore += arr.reduce((s,n,i)=>s+n*(i+1),0);
+        });
+        return totalVotes ? (totalScore / totalVotes).toFixed(2) : 0;
+      });
+
+      if (!chart) {
+        const ctx = document.getElementById('chartCanvas');
+        chart = new Chart(ctx, {
+          type: 'bar',
+          data: {
+            labels: candidates,
+            datasets: [{
+              label: 'Average Score',
+              data: averages,
+              backgroundColor: 'rgba(34,211,238,0.5)'
+            }]
+          },
+          options: {
+            scales: { y: { beginAtZero: true, max: 5 } }
+          }
+        });
+      } else {
+        chart.data.labels = candidates;
+        chart.data.datasets[0].data = averages;
+        chart.update();
+      }
+    }
+
+    socket.on('tally', (data) => {
+      const { contestName, candidates, categories, counts } = data;
+      lastData = data;
       document.title = contestName + ' – Live Results';
       document.getElementById('title').textContent = contestName + ' Results';
       list.innerHTML = '';
@@ -42,7 +88,19 @@
         div.innerHTML = `<h3>${c}</h3><ul>${items}</ul>`;
         list.appendChild(div);
       });
+      if (chartContainer.style.display !== 'none') {
+        updateChart(candidates, categories, counts);
+      }
     });
+
+    toggleBtn.onclick = () => {
+      const showingChart = chartContainer.style.display !== 'none';
+      chartContainer.style.display = showingChart ? 'none' : 'block';
+      list.style.display = showingChart ? 'grid' : 'none';
+      if (!showingChart && lastData) {
+        updateChart(lastData.candidates, lastData.categories, lastData.counts);
+      }
+    };
 
     resetBtn.onclick = () => socket.emit('reset');
   </script>

--- a/server.js
+++ b/server.js
@@ -8,22 +8,22 @@ const app = express();
 const server = http.createServer(app);
 const io = new Server(server);
 
-const CONTEST_NAME = process.env.CONTEST_NAME || 'Chili Cook‑Off';
-const CANDIDATES = (process.env.CANDIDATES || 'Chili 1,Chili 2,Chili 3')
+let contestName = process.env.CONTEST_NAME || 'Chili Cook‑Off';
+let candidates = (process.env.CANDIDATES || 'Chili 1,Chili 2,Chili 3')
   .split(',')
   .map(s => s.trim())
   .filter(Boolean);
-const CATEGORIES = (process.env.CATEGORIES || 'Appearance,Aroma,Consistency,Taste,Spiciness')
+let categories = (process.env.CATEGORIES || 'Appearance,Aroma,Consistency,Taste,Spiciness')
   .split(',')
   .map(s => s.trim())
   .filter(Boolean);
 
 function createEmptyCounts () {
   return Object.fromEntries(
-    CANDIDATES.map(c => [
+    candidates.map(c => [
       c,
       Object.fromEntries(
-        CATEGORIES.map(cat => [cat, [0, 0, 0, 0, 0]])
+        categories.map(cat => [cat, [0, 0, 0, 0, 0]])
       )
     ])
   );
@@ -31,46 +31,57 @@ function createEmptyCounts () {
 
 let counts = createEmptyCounts();
 
+app.use(express.json());
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.get('/', (_req, res) => res.redirect('/vote.html'));
 
 app.get('/config', (_req, res) => {
-  res.json({ contestName: CONTEST_NAME, candidates: CANDIDATES, categories: CATEGORIES });
+  res.json({ contestName, candidates, categories });
 });
 
 app.get('/reset', (_req, res) => {
   counts = createEmptyCounts();
-  io.emit('tally', { contestName: CONTEST_NAME, candidates: CANDIDATES, categories: CATEGORIES, counts });
+  io.emit('tally', { contestName, candidates, categories, counts });
   res.json({ ok: true, counts });
 });
 
+app.post('/setup', (req, res) => {
+  const { contestName: name, candidates: cand, categories: cat } = req.body || {};
+  if (typeof name === 'string') contestName = name;
+  if (Array.isArray(cand)) candidates = cand.filter(Boolean);
+  if (Array.isArray(cat)) categories = cat.filter(Boolean);
+  counts = createEmptyCounts();
+  io.emit('tally', { contestName, candidates, categories, counts });
+  res.json({ ok: true, contestName, candidates, categories });
+});
+
 io.on('connection', (socket) => {
-  socket.emit('tally', { contestName: CONTEST_NAME, candidates: CANDIDATES, categories: CATEGORIES, counts });
+  socket.emit('tally', { contestName, candidates, categories, counts });
 
   socket.on('cast-vote', ({ candidate, ratings }) => {
     if (typeof candidate !== 'string' || !counts[candidate]) return;
     if (typeof ratings !== 'object' || ratings === null) return;
     for (const [cat, val] of Object.entries(ratings)) {
-      if (!CATEGORIES.includes(cat)) continue;
+      if (!categories.includes(cat)) continue;
       const n = Number(val);
       if (n >= 1 && n <= 5) counts[candidate][cat][n - 1] += 1;
     }
-    io.emit('tally', { contestName: CONTEST_NAME, candidates: CANDIDATES, categories: CATEGORIES, counts });
+    io.emit('tally', { contestName, candidates, categories, counts });
   });
 
   socket.on('reset', () => {
     counts = createEmptyCounts();
-    io.emit('tally', { contestName: CONTEST_NAME, candidates: CANDIDATES, categories: CATEGORIES, counts });
+    io.emit('tally', { contestName, candidates, categories, counts });
   });
 });
 
 const PORT = process.env.PORT || 3000;
 server.listen(PORT, () => {
   console.log(`Live Vote server running on http://localhost:${PORT}`);
-  console.log(`Contest: ${CONTEST_NAME}`);
-  console.log(`Candidates: ${CANDIDATES.join(' | ')}`);
-  console.log(`Categories: ${CATEGORIES.join(' | ')}`);
+  console.log(`Contest: ${contestName}`);
+  console.log(`Candidates: ${candidates.join(' | ')}`);
+  console.log(`Categories: ${categories.join(' | ')}`);
   console.log('Vote page:    /vote.html');
   console.log('Display page: /display.html');
 });


### PR DESCRIPTION
## Summary
- Allow server-side contest reconfiguration via new `/setup` endpoint
- Provide admin page to manage contest name, contestants, and categories
- Add toggleable Chart.js view to display averages for each contestant

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68bcc5497154832ba05ec07aab899bec