### PR TITLE
Add multi-contest support and prevent duplicate votes

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -11,6 +11,10 @@
     <div class="card">
       <h1>Contest Setup</h1>
       <div style="margin-bottom:10px;">
+        <label for="contest-id">Contest ID:</label>
+        <input id="contest-id" style="width:100%;" />
+      </div>
+      <div style="margin-bottom:10px;">
         <label for="contest-name">Contest Name:</label>
         <input id="contest-name" style="width:100%;" />
       </div>
@@ -31,22 +35,29 @@
   </div>
 
   <script>
+    const idInput = document.getElementById('contest-id');
     const nameInput = document.getElementById('contest-name');
     const contestantsInput = document.getElementById('contestants');
     const categoriesInput = document.getElementById('categories');
     const status = document.getElementById('status');
 
-    fetch('/config').then(r => r.json()).then(cfg => {
+    const params = new URLSearchParams(window.location.search);
+    const contestId = params.get('contest') || 'default';
+    idInput.value = contestId;
+
+    fetch('/config?contest=' + contestId).then(r => r.json()).then(cfg => {
       nameInput.value = cfg.contestName;
       contestantsInput.value = cfg.candidates.join(', ');
       categoriesInput.value = cfg.categories.join(', ');
     });
 
     document.getElementById('save').onclick = () => {
+      const id = idInput.value.trim() || 'default';
       fetch('/setup', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
+          id,
           contestName: nameInput.value,
           candidates: contestantsInput.value.split(',').map(s => s.trim()).filter(Boolean),
           categories: categoriesInput.value.split(',').map(s => s.trim()).filter(Boolean)
@@ -58,7 +69,8 @@
     };
 
     document.getElementById('reset').onclick = () => {
-      fetch('/reset');
+      const id = idInput.value.trim() || 'default';
+      fetch('/reset?contest=' + id);
     };
   </script>
 </body>

--- a/public/display.html
+++ b/public/display.html
@@ -26,7 +26,9 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="/socket.io/socket.io.js"></script>
   <script>
-    const socket = io();
+    const params = new URLSearchParams(window.location.search);
+    const contestId = params.get('contest') || 'default';
+    const socket = io({ query: { contest: contestId } });
     const resetBtn = document.getElementById('reset');
     const list = document.getElementById('list');
     const toggleBtn = document.getElementById('toggle-chart');

--- a/public/vote.html
+++ b/public/vote.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Cast Your Vote</title>
   <link rel="stylesheet" href="/style.css" />
+  <script src="https://unpkg.com/sweetalert/dist/sweetalert.min.js"></script>
 </head>
 <body>
   <div class="wrap">
@@ -25,9 +26,13 @@
         <button id="submit" class="btn btn-primary">Submit Vote 🌶️</button>
       </div>
       <div style="margin-top:10px;">
-        <a class="pill" href="/display.html">📊 View Live Results</a>
+        <a id="results-link" class="pill" href="">📊 View Live Results</a>
       </div>
       <p id="thanks" class="pill" style="display:none; margin-top:10px;">✅ Thanks for voting!</p>
+      <div id="legend" style="margin-top:10px;">
+        <strong>Voted contestants:</strong>
+        <ul id="voted-list"></ul>
+      </div>
     </div>
     <div class="footer">Demo only — in‑memory votes; resets when the server restarts.</div>
   </div>
@@ -35,25 +40,42 @@
   <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script>
   <script src="/socket.io/socket.io.js"></script>
   <script>
-    const socket = io();
+    const params = new URLSearchParams(window.location.search);
+    const contestId = params.get('contest') || 'default';
+    const socket = io({ query: { contest: contestId } });
     const candidateSelect = document.getElementById('candidate');
     const categoriesDiv = document.getElementById('categories');
     const thanks = document.getElementById('thanks');
     const shareLink = document.getElementById('share-link');
+    const resultsLink = document.getElementById('results-link');
     const qrCanvas = document.getElementById('qr-code');
+    const votedList = document.getElementById('voted-list');
     const selections = {};
     let categories = [];
 
-    const url = window.location.href;
+    const url = window.location.origin + '/vote.html?contest=' + contestId;
     shareLink.textContent = url;
     shareLink.href = url;
+    resultsLink.href = '/display.html?contest=' + contestId;
     if (window.QRCode) {
       QRCode.toCanvas(qrCanvas, url, { width: 128 }, err => {
         if (err) console.error(err);
       });
     }
 
-    fetch('/config').then(r => r.json()).then(cfg => {
+    const votedKey = 'votedCandidates_' + contestId;
+    const voted = JSON.parse(localStorage.getItem(votedKey) || '[]');
+    function updateLegend () {
+      votedList.innerHTML = '';
+      voted.forEach(c => {
+        const li = document.createElement('li');
+        li.textContent = c;
+        votedList.appendChild(li);
+      });
+    }
+    updateLegend();
+
+    fetch('/config?contest=' + contestId).then(r => r.json()).then(cfg => {
       document.title = cfg.contestName + ' – Cast Your Vote';
       document.getElementById('title').textContent = cfg.contestName;
       cfg.candidates.forEach(c => {
@@ -87,11 +109,18 @@
     document.getElementById('submit').onclick = () => {
       const candidate = candidateSelect.value;
       if (!candidate) return;
+      if (voted.includes(candidate)) {
+        swal('Vote already registered', 'You have already voted for this contestant.', 'info');
+        return;
+      }
       const ratings = {};
       categories.forEach(cat => {
         if (selections[cat]) ratings[cat] = selections[cat];
       });
       socket.emit('cast-vote', { candidate, ratings });
+      voted.push(candidate);
+      localStorage.setItem(votedKey, JSON.stringify(voted));
+      updateLegend();
       thanks.style.display = 'inline-flex';
       setTimeout(() => (thanks.style.display = 'none'), 1500);
       categoriesDiv.querySelectorAll('.rating-btn.selected').forEach(btn => btn.classList.remove('selected'));

--- a/server.js
+++ b/server.js
@@ -8,17 +8,16 @@ const app = express();
 const server = http.createServer(app);
 const io = new Server(server);
 
-let contestName = process.env.CONTEST_NAME || 'Chili Cook‑Off';
-let candidates = (process.env.CANDIDATES || 'Chili 1,Chili 2,Chili 3')
-  .split(',')
-  .map(s => s.trim())
-  .filter(Boolean);
-let categories = (process.env.CATEGORIES || 'Appearance,Aroma,Consistency,Taste,Spiciness')
-  .split(',')
-  .map(s => s.trim())
-  .filter(Boolean);
+const DEFAULT_CONTEST = 'default';
 
-function createEmptyCounts () {
+function parseList (str, fallback) {
+  return (str || fallback)
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+}
+
+function createEmptyCounts (candidates, categories) {
   return Object.fromEntries(
     candidates.map(c => [
       c,
@@ -29,59 +28,100 @@ function createEmptyCounts () {
   );
 }
 
-let counts = createEmptyCounts();
+const contests = {};
+const defaultContest = {
+  contestName: process.env.CONTEST_NAME || 'Chili Cook‑Off',
+  candidates: parseList(process.env.CANDIDATES, 'Chili 1,Chili 2,Chili 3'),
+  categories: parseList(
+    process.env.CATEGORIES,
+    'Appearance,Aroma,Consistency,Taste,Spiciness'
+  )
+};
+defaultContest.counts = createEmptyCounts(
+  defaultContest.candidates,
+  defaultContest.categories
+);
+contests[DEFAULT_CONTEST] = defaultContest;
 
 app.use(express.json());
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.get('/', (_req, res) => res.redirect('/vote.html'));
 
-app.get('/config', (_req, res) => {
+app.get('/config', (req, res) => {
+  const id = req.query.contest || DEFAULT_CONTEST;
+  const contest = contests[id];
+  if (!contest) return res.status(404).json({ error: 'Contest not found' });
+  const { contestName, candidates, categories } = contest;
   res.json({ contestName, candidates, categories });
 });
 
-app.get('/reset', (_req, res) => {
-  counts = createEmptyCounts();
-  io.emit('tally', { contestName, candidates, categories, counts });
-  res.json({ ok: true, counts });
+app.get('/reset', (req, res) => {
+  const id = req.query.contest || DEFAULT_CONTEST;
+  const contest = contests[id];
+  if (!contest) return res.status(404).json({ error: 'Contest not found' });
+  contest.counts = createEmptyCounts(contest.candidates, contest.categories);
+  io.to(id).emit('tally', contest);
+  res.json({ ok: true, counts: contest.counts });
 });
 
 app.post('/setup', (req, res) => {
-  const { contestName: name, candidates: cand, categories: cat } = req.body || {};
-  if (typeof name === 'string') contestName = name;
-  if (Array.isArray(cand)) candidates = cand.filter(Boolean);
-  if (Array.isArray(cat)) categories = cat.filter(Boolean);
-  counts = createEmptyCounts();
-  io.emit('tally', { contestName, candidates, categories, counts });
-  res.json({ ok: true, contestName, candidates, categories });
+  const { id = DEFAULT_CONTEST, contestName: name, candidates: cand, categories: cat } = req.body || {};
+  let contest = contests[id];
+  if (!contest) {
+    contest = { contestName: 'Contest', candidates: [], categories: [], counts: {} };
+    contests[id] = contest;
+  }
+  if (typeof name === 'string') contest.contestName = name;
+  if (Array.isArray(cand)) contest.candidates = cand.filter(Boolean);
+  if (Array.isArray(cat)) contest.categories = cat.filter(Boolean);
+  contest.counts = createEmptyCounts(contest.candidates, contest.categories);
+  io.to(id).emit('tally', contest);
+  res.json({ ok: true, contestId: id, contestName: contest.contestName, candidates: contest.candidates, categories: contest.categories });
 });
 
 io.on('connection', (socket) => {
-  socket.emit('tally', { contestName, candidates, categories, counts });
+  const contestId = socket.handshake.query.contest || DEFAULT_CONTEST;
+  if (!contests[contestId]) {
+    contests[contestId] = {
+      contestName: 'Contest',
+      candidates: [],
+      categories: [],
+      counts: createEmptyCounts([], [])
+    };
+  }
+  const contest = contests[contestId];
+  socket.join(contestId);
+  socket.emit('tally', contest);
 
   socket.on('cast-vote', ({ candidate, ratings }) => {
-    if (typeof candidate !== 'string' || !counts[candidate]) return;
+    const contest = contests[contestId];
+    if (!contest) return;
+    if (typeof candidate !== 'string' || !contest.counts[candidate]) return;
     if (typeof ratings !== 'object' || ratings === null) return;
     for (const [cat, val] of Object.entries(ratings)) {
-      if (!categories.includes(cat)) continue;
+      if (!contest.categories.includes(cat)) continue;
       const n = Number(val);
-      if (n >= 1 && n <= 5) counts[candidate][cat][n - 1] += 1;
+      if (n >= 1 && n <= 5) contest.counts[candidate][cat][n - 1] += 1;
     }
-    io.emit('tally', { contestName, candidates, categories, counts });
+    io.to(contestId).emit('tally', contest);
   });
 
   socket.on('reset', () => {
-    counts = createEmptyCounts();
-    io.emit('tally', { contestName, candidates, categories, counts });
+    const contest = contests[contestId];
+    if (!contest) return;
+    contest.counts = createEmptyCounts(contest.candidates, contest.categories);
+    io.to(contestId).emit('tally', contest);
   });
 });
 
 const PORT = process.env.PORT || 3000;
 server.listen(PORT, () => {
+  const { contestName, candidates, categories } = contests[DEFAULT_CONTEST];
   console.log(`Live Vote server running on http://localhost:${PORT}`);
   console.log(`Contest: ${contestName}`);
   console.log(`Candidates: ${candidates.join(' | ')}`);
   console.log(`Categories: ${categories.join(' | ')}`);
-  console.log('Vote page:    /vote.html');
-  console.log('Display page: /display.html');
+  console.log(`Vote page:    /vote.html?contest=${DEFAULT_CONTEST}`);
+  console.log(`Display page: /display.html?contest=${DEFAULT_CONTEST}`);
 });


### PR DESCRIPTION
## Summary
- Allow server and clients to manage multiple contests via contest IDs
- Prevent duplicate votes per contestant with SweetAlert and local storage tracking
- Admin setup page now accepts contest IDs for creating and resetting separate contests

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bce93a9e8c832ba0505f02b3a67f54